### PR TITLE
Link directly to the security reporting page

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,6 @@
 
 ## Reporting a vulnerability
 
-If you find a security issue or vulnerability, please **do not** open a public issue. Instead, **[use the dedicated vulnerability reporting page](https://github.com/RiverBench/RiverBench/security)**.
+If you find a security issue or vulnerability, please **do not** open a public issue. Instead, **[use the dedicated vulnerability reporting page](https://github.com/RiverBench/RiverBench/security/advisories/new)**.
 
 We will get back to you as soon as possible.


### PR DESCRIPTION
Currently, the security policy document can feel like it points to itself: when you click the link, it opens up a page with the same document again and a single button to actually file the report. Let's provide a link directly to the security advisory form—we can refer to the general security page as "past vulnerabilities resolved", but atm, with no content other than the security policy, it can be sort-of confusing. If this PR gets accepted, I'll create analogous ones for the rest of the projects.